### PR TITLE
✨ [feat] Added CI/CD pipeline for build automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        platforms:
-          - linux-x64
-          - darwin-x64
-          - win-x64
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            platform: win-x64
+          - os: macos-latest
+            platform: osx.12-x64
+          - os: ubuntu-latest
+            platform: linux-x64
 
     steps:
     - name: Checkout
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build
       run: |
-        dotnet publish -r ${{ matrix.platforms }} -c Release --self-contained true
+        dotnet publish -r ${{ matrix.platform }} -c Release --self-contained true
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,7 @@ jobs:
       run: |
         dotnet publish -r win-x64 -c Release --self-contained true
 
-    - name: List changed files
-      run: |
-        git diff --name-only
-
-    # - name: Upload artifact
-    #   uses: actions/upload-artifact@v3
-      
-    
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: D:\a\GarryMC\GarryMC\bin\Release\net7.0\win-x64\publish\*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: .NET Core Desktop
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+
+    - name: Build
+      run: |
+        dotnet publish -r win-x64 -c Release --self-contained true
+
+    - name: Get changed files
+      uses: jitterbit/get-changed-files@v1
+      id: files
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: ${{ steps.files.outputs.all }}
+    

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: .NET Core Desktop
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
           - os: macos-latest
             platform: osx-x64
-            path: /Users/runner/work/GarryMC/GarryMC/bin/Release/net7.0/osx.12-x64/publish/*
+            path: /Users/runner/work/GarryMC/GarryMC/bin/Release/net7.0/osx-x64/publish/*
             name: garry-osx
 
           - os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,18 @@ jobs:
         include:
           - os: windows-latest
             platform: win-x64
+            path: D:\a\GarryMC\GarryMC\bin\Release\net7.0\win-x64\publish\*
+            name: garry-win
+
           - os: macos-latest
-            platform: osx.12-x64
+            platform: osx-x64
+            path: /Users/runner/work/GarryMC/GarryMC/bin/Release/net7.0/osx.12-x64/publish/*
+            name: garry-osx
+
           - os: ubuntu-latest
             platform: linux-x64
+            path: /home/runner/work/GarryMC/GarryMC/bin/Release/net7.0/linux-x64/publish/*
+            name: garry-linux
 
     steps:
     - name: Checkout
@@ -35,7 +43,8 @@ jobs:
       run: |
         dotnet publish -r ${{ matrix.platform }} -c Release --self-contained true
 
-    # - name: Upload artifact
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     path: D:\a\GarryMC\GarryMC\bin\Release\net7.0\win-x64\publish\*
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.name }}
+        path: ${{ matrix.path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,19 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        configuration: [Release]
-
-    runs-on: windows-latest
+        platforms:
+          - linux-x64
+          - darwin-x64
+          - win-x64
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
 
     steps:
     - name: Checkout
@@ -25,7 +33,7 @@ jobs:
 
     - name: Build
       run: |
-        dotnet publish -r win-x64 -c Release --self-contained true
+        dotnet publish -r ${{ matrix.platforms }} -c Release --self-contained true
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        configuration: [Debug, Release]
+        configuration: [Release]
 
     runs-on: windows-latest
 
@@ -27,12 +27,11 @@ jobs:
       run: |
         dotnet publish -r win-x64 -c Release --self-contained true
 
-    - name: Get changed files
-      uses: jitterbit/get-changed-files@v1
-      id: files
+    - name: List changed files
+      run: |
+        git diff --name-only
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        path: ${{ steps.files.outputs.all }}
+    # - name: Upload artifact
+    #   uses: actions/upload-artifact@v3
+      
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         dotnet publish -r ${{ matrix.platform }} -c Release --self-contained true
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        path: D:\a\GarryMC\GarryMC\bin\Release\net7.0\win-x64\publish\*
+    # - name: Upload artifact
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     path: D:\a\GarryMC\GarryMC\bin\Release\net7.0\win-x64\publish\*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dotnet publish -r win-x64 -c Release --self-contained true
 ```
 Make sure to replace win-x64 with your OS.
 
-Your build will be located in GarryMC\obj\Release\net7.0\yourOS\publish
+Your build will be located in: `GarryMC\obj\Release\net7.0\<yourOS>\publish`
 
 # Contribution
 Contributing to GarryMC is simple. You have to fork the repository and clone it. Make your changes. After you are done, just push the changes to your fork and make a pull request. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # GarryMC
 GarryMC is an asynchronous Minecraft server lookup tool that runs in your terminal using [Spectre.Console](https://github.com/spectreconsole/spectre.console). 
 
+[![Build](https://github.com/Itsmemonzu/GarryMC/actions/workflows/build.yml/badge.svg)](https://github.com/Itsmemonzu/GarryMC/actions/workflows/build.yml)
+
+<br>
+
 ## Installation & Usage 
 This program is dependant on [Spectre.Console](https://github.com/spectreconsole/spectre.console). To build the program, you need to use
 ```
@@ -12,7 +16,7 @@ dotnet publish -r win-x64 -c Release --self-contained true
 ```
 Make sure to replace win-x64 with your OS.
 
-Your build will be located in: `GarryMC\obj\Release\net7.0\<yourOS>\publish`
+Your build will be located in: `GarryMC\obj\Release\net7.0\<yourOS>\publish` <br>
 
 # Contribution
 Contributing to GarryMC is simple. You have to fork the repository and clone it. Make your changes. After you are done, just push the changes to your fork and make a pull request. 


### PR DESCRIPTION
This PR adds the functionality to automatically build GarryMC for three different major desktop platforms.

Steps:
- Setting up the workflow
- Building using .NET Core Desktop
- Uploading the artifacts using predefined paths (might cause issues if path is dynamic)