### PR TITLE
🔨 [tuning] Added concurrency to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds the `concurrency` attribute to the `build.yml` workflow for ensuring proper GitHub Actions execution with multiple pushes.